### PR TITLE
Added support for Ractive 0.9

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,11 @@ var mergeOptions = {
 module.exports.apply = function(ractive, diff) {
 	ractive.set(diff.set)
 	diff.merge.forEach(function(arrayToMerge) {
-		ractive.merge(arrayToMerge.keypath, arrayToMerge.array, mergeOptions)
+		if(ractive.merge) {
+			ractive.merge(arrayToMerge.keypath, arrayToMerge.array, mergeOptions)
+		}
+		else {
+			ractive.set(arrayToMerge.keypath, arrayToMerge.array, Object.assign({}, mergeOptions, { deep: true }))
+		}
 	})
 }


### PR DESCRIPTION
In Ractive 0.9, `ractive.merge` is replaced with `ractive.set` with a `{ deep: true }` option.

https://github.com/ractivejs/ractive/blob/dev/CHANGELOG.md#090